### PR TITLE
[ALS-6225] Manage dependencies through maven

### DIFF
--- a/generate-module-xml.sh
+++ b/generate-module-xml.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Directory where JAR files are located
+JAR_DIR="/opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main"
+
+# Start of the module.xml file
+cat <<EOF > ${JAR_DIR}/module.xml
+<module xmlns="urn:jboss:module:1.1" name="com.sql.mysql">
+    <resources>
+EOF
+
+# Loop through all JAR files and add them as resource-root entries
+for jar in ${JAR_DIR}/*.jar; do
+    echo "        <resource-root path=\"$(basename $jar)\"/>" >> ${JAR_DIR}/module.xml
+done
+
+# End of the module.xml file
+cat <<EOF >> ${JAR_DIR}/module.xml
+    </resources>
+    <dependencies>
+        <module name="javax.api"/>
+    </dependencies>
+</module>
+EOF

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -20,8 +20,7 @@ FROM jboss/wildfly:17.0.0.Final
 # Now, copy the resolved dependencies from the 'dependencies' stage into the WildFly deployments directory
 COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/
 # Copy the script that generates module.xml
-COPY generate-module-xml.sh /tmp/generate-module-xml.sh
-# Run the script to generate module.xml dynamically
+COPY --chown=jboss:jboss generate-module-xml.sh /tmp/generate-module-xml.sh
 RUN /tmp/generate-module-xml.sh
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -21,7 +21,7 @@ FROM jboss/wildfly:17.0.0.Final
 COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/
 # Copy the script that generates module.xml
 COPY --chown=jboss:jboss generate-module-xml.sh /tmp/generate-module-xml.sh
-RUN /tmp/generate-module-xml.sh
+RUN chmod +x /tmp/generate-module-xml.sh && /tmp/generate-module-xml.sh
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war
 COPY --from=PSAMA /opt/jboss/wildfly/standalone/deployments/pic-sure-auth-services.war /tmp/pic-sure-auth-services.war

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -22,7 +22,7 @@ COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/modules/syst
 # Copy the script that generates module.xml
 COPY generate-module-xml.sh /tmp/generate-module-xml.sh
 # Run the script to generate module.xml dynamically
-RUN chmod +x /tmp/generate-module-xml.sh && /tmp/generate-module-xml.sh
+RUN /tmp/generate-module-xml.sh
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war
 COPY --from=PSAMA /opt/jboss/wildfly/standalone/deployments/pic-sure-auth-services.war /tmp/pic-sure-auth-services.war

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -24,6 +24,9 @@ COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/modules/syst
 COPY generate-module-xml.sh /tmp/generate-module-xml.sh
 RUN chmod +x /tmp/generate-module-xml.sh && /tmp/generate-module-xml.sh
 
+# cat the generated module.xml file to see if it was generated correctly
+RUN cat /opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/module.xml
+
 USER jboss
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -18,7 +18,7 @@ FROM hms-dbmi/pic-sure-visualization-resource:${PIC_SURE_VISUALIZATION_VERSION} 
 FROM jboss/wildfly:17.0.0.Final
 
 # Now, copy the resolved dependencies from the 'dependencies' stage into the WildFly deployments directory
-COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/standalone/deployments/
+COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war
 COPY --from=PSAMA /opt/jboss/wildfly/standalone/deployments/pic-sure-auth-services.war /tmp/pic-sure-auth-services.war

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -31,6 +31,6 @@ COPY --from=PSV /opt/jboss/wildfly/standalone/deployments/pic-sure-visualization
 
 USER root
 
-RUN mv /tmp/*.war /opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/
+RUN mv /tmp/*.war /opt/jboss/wildfly/standalone/deployments/
 
 USER jboss

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -3,12 +3,22 @@ ARG PIC_SURE_AUTH_VERSION
 ARG PIC_SURE_AGGREGATE_VERSION
 ARG PIC_SURE_VISUALIZATION_VERSION
 
+# Define a stage for dependency resolution using Maven
+FROM maven:3.6.3-jdk-11 as dependencies
+# Copy your pom.xml file into the image
+COPY pom.xml /tmp/
+# Resolve and download dependencies, potentially using the dependency:copy-dependencies goal to place them into a target directory
+RUN mvn -f /tmp/pom.xml dependency:copy-dependencies -DoutputDirectory=/tmp/dependencies
+
 FROM hms-dbmi/pic-sure-api:${PIC_SURE_API_VERSION} as PSA
 FROM hms-dbmi/pic-sure-auth-microapp:${PIC_SURE_AUTH_VERSION} as PSAMA
 FROM hms-dbmi/pic-sure-aggregate-resource:${PIC_SURE_AGGREGATE_VERSION} as PSAGG
 FROM hms-dbmi/pic-sure-visualization-resource:${PIC_SURE_VISUALIZATION_VERSION} as PSV
 
 FROM jboss/wildfly:17.0.0.Final
+
+# Now, copy the resolved dependencies from the 'dependencies' stage into the WildFly deployments directory
+COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/standalone/deployments/
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war
 COPY --from=PSAMA /opt/jboss/wildfly/standalone/deployments/pic-sure-auth-services.war /tmp/pic-sure-auth-services.war

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -17,11 +17,14 @@ FROM hms-dbmi/pic-sure-visualization-resource:${PIC_SURE_VISUALIZATION_VERSION} 
 
 FROM jboss/wildfly:17.0.0.Final
 
+USER root
 # Now, copy the resolved dependencies from the 'dependencies' stage into the WildFly deployments directory
 COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/
 # Copy the script that generates module.xml
-COPY --chown=jboss:jboss generate-module-xml.sh /tmp/generate-module-xml.sh
+COPY generate-module-xml.sh /tmp/generate-module-xml.sh
 RUN chmod +x /tmp/generate-module-xml.sh && /tmp/generate-module-xml.sh
+
+USER jboss
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war
 COPY --from=PSAMA /opt/jboss/wildfly/standalone/deployments/pic-sure-auth-services.war /tmp/pic-sure-auth-services.war

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -19,13 +19,15 @@ FROM jboss/wildfly:17.0.0.Final
 
 # Now, copy the resolved dependencies from the 'dependencies' stage into the WildFly deployments directory
 COPY --from=dependencies /tmp/dependencies/*.jar /opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/
+# Copy the script that generates module.xml
+COPY generate-module-xml.sh /tmp/generate-module-xml.sh
+# Run the script to generate module.xml dynamically
+RUN chmod +x /tmp/generate-module-xml.sh && /tmp/generate-module-xml.sh
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war
 COPY --from=PSAMA /opt/jboss/wildfly/standalone/deployments/pic-sure-auth-services.war /tmp/pic-sure-auth-services.war
 COPY --from=PSAGG /opt/jboss/wildfly/standalone/deployments/pic-sure-aggregate-data-sharing-resource.war  /tmp/pic-sure-aggregate-resource.war
 COPY --from=PSV /opt/jboss/wildfly/standalone/deployments/pic-sure-visualization-resource.war  /tmp/pic-sure-visualization-resource.war
-
-
 
 USER root
 

--- a/pic-sure-with-aggregate-resource.Dockerfile
+++ b/pic-sure-with-aggregate-resource.Dockerfile
@@ -29,6 +29,6 @@ COPY --from=PSV /opt/jboss/wildfly/standalone/deployments/pic-sure-visualization
 
 USER root
 
-RUN mv /tmp/*.war /opt/jboss/wildfly/standalone/deployments/
+RUN mv /tmp/*.war /opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/
 
 USER jboss

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,12 @@
             <artifactId>aws-secretsmanager-jdbc</artifactId>
             <version>2.0.2</version>
         </dependency>
+        <!-- MySQL Connector dependency -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.33</version>
+        </dependency>
     </dependencies>
     <build>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Your project coordinates -->
+    <groupId>com.hms.dbmi</groupId>
+    <artifactId>dependency_jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>dbmi_wildfly_dependencies</name>
+    <description>This project was created, so we can use maven for dependency management.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- AWS Secrets Manager JDBC dependency -->
+        <dependency>
+            <groupId>com.amazonaws.secretsmanager</groupId>
+            <artifactId>aws-secretsmanager-jdbc</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+    </dependencies>
+    <build>
+    </build>
+</project>


### PR DESCRIPTION
### Dependency Management Improvement
Previously, dependencies were manually managed by uploading them to an S3 bucket and then downloading them onto the EC2 instance at startup. Now, they are included during the creation of the Docker image. Here's how the enhancement was achieved:

- **Introduction of `pom.xml` File**: A `pom.xml` file was introduced for efficient dependency management.
- **Updated Dockerfile**: The Dockerfile was updated to utilize Maven in a multi-stage build process.
- **File Copying**: All files from the first stage are copied to the required location on WildFly.
- **Automatic `module.xml` Generation**: The `module.xml` file is automatically generated based on the JAR files downloaded by Maven.
