### PR TITLE
[ALS-6100] All-in-one: Move PSAMA to its own Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ FROM hms-dbmi/pic-sure-auth-microapp:${PIC_SURE_AUTH_VERSION} as PSAMA
 FROM jboss/wildfly:23.0.0.Final
 
 COPY --from=PSA /opt/jboss/wildfly/standalone/deployments/pic-sure-api-2.war /tmp/pic-sure-api-2.war
-COPY --from=PSAMA /opt/jboss/wildfly/standalone/deployments/pic-sure-auth-services.war /tmp/pic-sure-auth-services.war
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 ARG PIC_SURE_API_VERSION
-ARG PIC_SURE_AUTH_VERSION
 
 FROM hms-dbmi/pic-sure-api:${PIC_SURE_API_VERSION} as PSA
-FROM hms-dbmi/pic-sure-auth-microapp:${PIC_SURE_AUTH_VERSION} as PSAMA
 
 FROM jboss/wildfly:23.0.0.Final
 


### PR DESCRIPTION
Remove PSAMA from the Docker build. We no longer deploy PSAMA as part of our WildFly deployment. It is now deployed as a standalone Docker container.